### PR TITLE
Add mutations and increase max_ref to more fully cover B.1.526: see #22

### DIFF
--- a/constellations/definitions/cB.1.526.json
+++ b/constellations/definitions/cB.1.526.json
@@ -36,11 +36,15 @@
 		"N:P199L",
 		"N:M234I",
 		"ORF8:T11I",
+		"S:S477N",
+		"S:Q957R",
+		"N:P13L",
+		"N:S202R",
         "nuc:A28271-"
     ],
     "rules": {
         "min_alt": 11,
-        "max_ref": 3
+        "max_ref": 7
     }
 }
 


### PR DESCRIPTION
B.1.526/Iota is split into two major branches, one with {S:E484K, S:A701V, N:P199L, N:M234I} and the other with {S:S477N, S:Q957R, N:P13L, N:S202R}.  cB.1.526.json included mutations for the first branch but not the second.  Even pango-designation representative sequences for B.1.526 in the second branch were failing the max_ref=3 threshold due to having 4 reference alleles for first branch's mutations.  To cover both branches, this change adds four mutations for the second branch and increases max_ref to 7.

Closes #22.