### PR TITLE
Dev

### DIFF
--- a/constellations/__init__.py
+++ b/constellations/__init__.py
@@ -1,3 +1,3 @@
 _program = "constellations"
-__version__ = "v0.0.16"
+__version__ = "v0.0.17"
 

--- a/constellations/definitions/cAY.4.2.json
+++ b/constellations/definitions/cAY.4.2.json
@@ -34,7 +34,7 @@
         "min_alt": 3,
         "max_ref": 1,
         "spike:Y145H": "alt",
-        "spike:A222V": "alt",
+        "spike:A222V": "not ref",
         "nuc:T17040C": "alt"
     }
 }

--- a/constellations/definitions/cAY.4.2.json
+++ b/constellations/definitions/cAY.4.2.json
@@ -62,8 +62,8 @@
     "rules": {
         "min_alt": 32,
         "max_ref": 3,
-        "spike:Y145H": "not ref",
+        "spike:Y145H": "alt",
         "spike:A222V": "alt",
-        "nuc:T17040C": "alt
+        "nuc:T17040C": "alt"
     }
 }

--- a/constellations/definitions/cAY.4.2.json
+++ b/constellations/definitions/cAY.4.2.json
@@ -62,7 +62,8 @@
     "rules": {
         "min_alt": 32,
         "max_ref": 3,
-        "spike:Y145H": "alt",
-        "spike:A222V": "alt"
+        "spike:Y145H": "not ref",
+        "spike:A222V": "alt",
+        "nuc:T17040C": "alt
     }
 }

--- a/constellations/definitions/cAY.4.2.json
+++ b/constellations/definitions/cAY.4.2.json
@@ -9,46 +9,17 @@
 	    "AY.4.2"
 	],
 	"mrca_lineage": "AY.4.2",
+        "lineage_name": "AY.4.2",
+        "parent_lineage": "AY.4",
 	"representative_genome": ""
     },
     "tags": [
 	"AY.4.2"
     ],
     "sites": [
-        "del:28271:1",
-        "del:28248:6",
-        "nuc:C3037T",
-        "orf1a:A1306S",
-        "orf1a:P2046L",
-        "orf1a:P2287S",
-        "orf1a:A2529V",
-        "nuc:C8986T",
-        "orf1a:V2930L",
-        "orf1a:T3255I",
-        "orf1a:T3646A",
-        "nuc:A11332G",
-        "orf1b:P314L",
-        "orf1b:G662S",
-        "orf1b:P1000L",
         "nuc:T17040C",
-        "orf1b:A1918V",
-        "spike:T19R",
         "spike:A222V",
-        "spike:L452R",
-        "spike:T478K",
-        "spike:D614G",
-        "spike:P681R",
-        "orf3a:S26L",
         "nuc:C25614T",
-        "m:I82T",
-        "orf7a:V82A",
-        "orf7a:T120I",
-        "nuc:C27874T",
-        "n:D63G",
-        "n:R203M",
-        "n:G215C",
-        "n:D377Y",
-        "nuc:G29742T",
         "spike:Y145H"
     ],
     "intermediate": [
@@ -60,8 +31,8 @@
         "spike:D950N:0.978338"
     ],
     "rules": {
-        "min_alt": 32,
-        "max_ref": 3,
+        "min_alt": 3,
+        "max_ref": 1,
         "spike:Y145H": "alt",
         "spike:A222V": "alt",
         "nuc:T17040C": "alt"

--- a/constellations/definitions/cAY.4.json
+++ b/constellations/definitions/cAY.4.json
@@ -1,22 +1,24 @@
 {
-    "label": "Delta (AY.4.2-like)",
-    "description": "AY.4.2 lineage defining mutations",
+    "label": "Delta (AY.4-like)",
+    "description": "AY.4 lineage defining mutations",
     "sources": [
     ],
     "type": "variant",
     "variant": {
 	"Pango_lineages": [
-	    "AY.4.2"
+	    "AY.4"
 	],
-	"mrca_lineage": "AY.4.2",
+	"mrca_lineage": "AY.4",
 	"representative_genome": ""
     },
     "tags": [
-	"AY.4.2"
+	"AY.4"
     ],
     "sites": [
         "del:28271:1",
+        "del:22029:6",
         "del:28248:6",
+        "nuc:C241T",
         "nuc:C3037T",
         "orf1a:A1306S",
         "orf1a:P2046L",
@@ -30,16 +32,14 @@
         "orf1b:P314L",
         "orf1b:G662S",
         "orf1b:P1000L",
-        "nuc:T17040C",
         "orf1b:A1918V",
         "spike:T19R",
-        "spike:A222V",
         "spike:L452R",
         "spike:T478K",
         "spike:D614G",
         "spike:P681R",
+        "spike:D950N",
         "orf3a:S26L",
-        "nuc:C25614T",
         "m:I82T",
         "orf7a:V82A",
         "orf7a:T120I",
@@ -48,21 +48,17 @@
         "n:R203M",
         "n:G215C",
         "n:D377Y",
-        "nuc:G29742T",
-        "spike:Y145H"
+        "nuc:G29742T"
     ],
     "intermediate": [
-        "del:22029:6:0.961207",
-        "nuc:G210T:0.978338",
-        "nuc:C241T:0.978338",
-        "spike:T95I:0.978338",
-        "spike:G142D:0.978338",
-        "spike:D950N:0.978338"
+        "nuc:G210T:0.976009",
+        "nuc:T17040C:0.976009",
+        "spike:T95I:0.976009",
+        "spike:G142D:0.976009"
     ],
     "rules": {
-        "min_alt": 32,
+        "min_alt": 31,
         "max_ref": 3,
-        "spike:Y145H": "alt",
-        "spike:A222V": "alt"
+        "orf1a:A2529V": "alt"
     }
 }

--- a/constellations/definitions/cAY.4.json
+++ b/constellations/definitions/cAY.4.json
@@ -9,6 +9,8 @@
 	    "AY.4"
 	],
 	"mrca_lineage": "AY.4",
+        "lineage_name": "AY.4",
+        "parent_lineage": "B.1.617.2",
 	"representative_genome": ""
     },
     "tags": [

--- a/constellations/definitions/cB.1.617.2.json
+++ b/constellations/definitions/cB.1.617.2.json
@@ -12,6 +12,7 @@
             "AY.2"
         ],
 	    "mrca_lineage": "B.1.617.2",
+        "lineage_name": "B.1.617.2",
         "incompatible_lineage_calls": [
             "AY.1",
             "AY.2"


### PR DESCRIPTION
Add constellations for AY.4 and AY.4.2
Add optional field to constellation files specifying that they inherit the parent mutations. Note that this requires `lineage_name` to be specified in the parent file