### PR TITLE
Dev

### DIFF
--- a/constellations/__init__.py
+++ b/constellations/__init__.py
@@ -1,3 +1,3 @@
 _program = "constellations"
-__version__ = "v0.1.1"
+__version__ = "v0.1.2"
 

--- a/constellations/definitions/cB.1.1.529.json
+++ b/constellations/definitions/cB.1.1.529.json
@@ -9,13 +9,10 @@
             "B.1.1.529"
         ],
         "WHO_label": "Omicron",
-	"mrca_lineage": "",
+	"mrca_lineage": "None",
         "representative_genome": "",
         "lineage_name": "B.1.1.529",
         "incompatible_lineage_calls": [
-            "BA.1",
-            "BA.2",
-            "BA.3"
         ]
     },
     "tags": [

--- a/constellations/definitions/cB.1.1.529.json
+++ b/constellations/definitions/cB.1.1.529.json
@@ -1,5 +1,5 @@
 {
-    "label": "Omicron (B.1.1.529-like)",
+    "label": "Omicron (Unassigned)",
     "description": "B.1.1.529 lineage defining mutations",
     "sources": [
     ],
@@ -9,7 +9,7 @@
             "B.1.1.529"
         ],
         "WHO_label": "Omicron",
-	"mrca_lineage": "B.1.1.529",
+	"mrca_lineage": "",
         "representative_genome": "",
         "lineage_name": "B.1.1.529",
         "incompatible_lineage_calls": [

--- a/constellations/definitions/cBA.1.json
+++ b/constellations/definitions/cBA.1.json
@@ -41,8 +41,15 @@
     "note": "Unique mutations for sublineage",
     "note2": "Requires ancestral mutation so scorpio tie breaks correctly",
     "rules": {
+      "default": {
         "min_alt": 10,
         "max_ref": 3,
         "spike:D614G": "not ref"
+      },
+      "Probable": {
+        "min_alt": 6,
+        "max_ref": 8,
+        "spike:D614G": "not ref"
+      }
     }
 }

--- a/constellations/definitions/cBA.2.json
+++ b/constellations/definitions/cBA.2.json
@@ -47,7 +47,15 @@
     ],
     "note": "Unique mutations for sublineage",
     "rules": {
+      "default": {
         "min_alt": 16,
-        "max_ref": 3
+        "max_ref": 3,
+        "spike:D614G": "not ref"
+      },
+      "Probable": {
+        "min_alt": 10,
+        "max_ref": 8,
+        "spike:D614G": "not ref"
+      }
     }
 }

--- a/constellations/definitions/cBA.3.json
+++ b/constellations/definitions/cBA.3.json
@@ -44,13 +44,13 @@
         "min_alt": 11,
         "max_ref": 3,
         "nuc:C832T": "not ref",
-        "nuc:C11235T": "not ref",
+        "nuc:C11235T": "not ref"
       },
       "Probable": {
         "min_alt": 6,
         "max_ref": 8,
         "nuc:C832T": "not ref",
-        "nuc:C11235T": "not ref",
+        "nuc:C11235T": "not ref"
       }
     }
 }

--- a/constellations/definitions/cBA.3.json
+++ b/constellations/definitions/cBA.3.json
@@ -45,14 +45,12 @@
         "max_ref": 3,
         "nuc:C832T": "not ref",
         "nuc:C11235T": "not ref",
-        "orf1ab:I5967V": "not ref"
       },
       "Probable": {
         "min_alt": 6,
         "max_ref": 8,
         "nuc:C832T": "not ref",
         "nuc:C11235T": "not ref",
-        "orf1ab:I5967V": "not ref"
       }
     }
 }

--- a/constellations/definitions/cBA.3.json
+++ b/constellations/definitions/cBA.3.json
@@ -40,10 +40,19 @@
     ],
     "note": "Unique mutations for sublineage",
     "rules": {
+      "default": {
         "min_alt": 11,
         "max_ref": 3,
         "nuc:C832T": "not ref",
         "nuc:C11235T": "not ref",
         "orf1ab:I5967V": "not ref"
+      },
+      "Probable": {
+        "min_alt": 6,
+        "max_ref": 8,
+        "nuc:C832T": "not ref",
+        "nuc:C11235T": "not ref",
+        "orf1ab:I5967V": "not ref"
+      }
     }
 }


### PR DESCRIPTION
Update to ensure that more lower quality samples that could be classified as sublineages BA.* get a "Probable Omicron (BA.*-like)" call instead of a parent call. Make the parent "Omicron (Unclassified)" and remove mrca_lineage field from it so that pangolin does not call lineage B.1.1.529 (there are no designated sequences)