### PR TITLE
remove duplicated mutations from omicron sublineages/recombinant

### DIFF
--- a/constellations/definitions/cBA.2.json
+++ b/constellations/definitions/cBA.2.json
@@ -29,7 +29,6 @@
         "orf1ab:SGF3675-",
         "nuc:C10198T",
         "nuc:G10447A",
-        "nuc:C15714T",
         "nuc:C12880T",
         "nuc:C15714T",
         "orf1ab:R5716C",

--- a/constellations/definitions/cBA.3.json
+++ b/constellations/definitions/cBA.3.json
@@ -27,7 +27,6 @@
         "nuc:C11235T",
         "nuc:C12880T",
         "nuc:C15714T",
-        "orf1ab:I5967V",
         "spike:A67V",
         "spike:Q493R",
         "del:21765:6",

--- a/constellations/definitions/cBA.4.json
+++ b/constellations/definitions/cBA.4.json
@@ -34,7 +34,6 @@
       "nuc:A20055G",
       "spike:T19I",
       "s:HV69-",
-      "nuc:T22200G",
       "spike:V213G",
       "spike:S371F",
       "spike:T376A",

--- a/constellations/definitions/cBA.5.json
+++ b/constellations/definitions/cBA.5.json
@@ -34,7 +34,6 @@
       "nuc:A20055G",
       "spike:T19I",
       "s:HV69-",
-      "nuc:T22200G",
       "spike:V213G",
       "spike:S371F",
       "spike:T376A",

--- a/constellations/definitions/cXE-parent2.json
+++ b/constellations/definitions/cXE-parent2.json
@@ -19,7 +19,6 @@
     "sites": [
         "nuc:C15714T",
         "nuc:C12880T",
-        "nuc:C15714T",
         "orf1ab:R5716C",
         "orf1ab:T6564I",
         "nuc:A20055G",

--- a/constellations/definitions/cXE.json
+++ b/constellations/definitions/cXE.json
@@ -22,9 +22,7 @@
     "sites": [
     "nuc:C3241T",
     "nuc:T5386G",
-	"nuc:C14599T",
-    "nuc:C12880T",
-    "nuc:A29510C"
+    "nuc:C14599T"
     ],
     "rules": {
         "min_alt": 2,


### PR DESCRIPTION
Some duplicated mutations were found within constellation, or between children to parent constellation.
Except these mutations were deliberately repeated to increase their weights for the call, I think we need to clean up these sites:

- nuc:C15714T were found duplicated within BA.2 and XE-parent2
- orf1ab:I5967V from BA.3 was already in the parent lineage
- nuc:T22200G and spike:V213G refer to the same site
- nuc:C12880T, nuc:A29510C from XE constellation are already included in XE-parent2

Please review the changes carefully and may need to adjust the rules accordingly as well. 
Cheers,
