### PR TITLE
Updated PHE_label and tags with new nomenclature

### DIFF
--- a/constellations/definitions/cA.23.1+E484K.json
+++ b/constellations/definitions/cA.23.1+E484K.json
@@ -9,14 +9,15 @@
         "Pango_lineages": [
             "A.23.1"
         ],
-	    "mrca_lineage": "A.23.1",
-        "PHE_label": "VUI-21FEB-01",
+        "mrca_lineage": "A.23.1",
+        "PHE_label": "V-21FEB-01",
         "representative_genome": ""
     },
     "tags": [
         "A.23.1",
         "VUI-21FEB-01",
-        "VUI202102/01"
+        "VUI202102/01",
+        "V-21FEB-01"
     ],
     "sites": [
         "nsp3:L741F",

--- a/constellations/definitions/cAV1.json
+++ b/constellations/definitions/cAV1.json
@@ -9,11 +9,12 @@
 			"AV.1"
 		],
 		"mrca_lineage": "AV.1",
-		"PHE_label": "VOC-20-DEC-01",
+		"PHE_label": "VOC-20DEC-01",
 		"representative_genome": ""
 	},
 	"tags": [
-		"AV.1"
+		"AV.1",
+		"VOC-20DEC-01"
 	],
 	"sites": [
 		"s:D80G",

--- a/constellations/definitions/cAY.4.2.json
+++ b/constellations/definitions/cAY.4.2.json
@@ -6,16 +6,17 @@
     "type": "variant",
     "variant": {
 	"Pango_lineages": [
-	    "AY.4.2"
+        "AY.4.2"
 	],
 	"mrca_lineage": "AY.4.2",
         "lineage_name": "AY.4.2",
         "parent_lineage": "AY.4",
-	"PHE_label": "VUI-21OCT-01",
+	"PHE_label": "V-21OCT-01",
 	"representative_genome": ""
     },
     "tags": [
-	"AY.4.2"
+	"AY.4.2",
+    "V-21OCT-01"
     ],
     "sites": [
         "nuc:T17040C",

--- a/constellations/definitions/cB.1.1.318.json
+++ b/constellations/definitions/cB.1.1.318.json
@@ -9,14 +9,15 @@
 		"Pango_lineages": [
 			"B.1.1.318"        
 		],
-	    "mrca_lineage": "B.1.1.318",
-		"PHE_label": "VUI-21FEB-04",
+        "mrca_lineage": "B.1.1.318",
+		"PHE_label": "V-21FEB-04",
 		"representative_genome": ""
     },
 	"tags": [
 		"B.1.1.318",
 		"VUI-21FEB-04",
-		"VUI202102/04"
+		"VUI202102/04",
+        "V-21FEB-04"
 	],
     "sites": [
         "nuc:C3961T",

--- a/constellations/definitions/cB.1.525.json
+++ b/constellations/definitions/cB.1.525.json
@@ -9,8 +9,8 @@
         "Pango_lineages": [
             "B.1.525"
         ],
-	    "mrca_lineage": "B.1.525",
-        "PHE_label": "VUI-21FEB-03",
+        "mrca_lineage": "B.1.525",
+        "PHE_label": "V-21FEB-03",
         "WHO_label": "Eta",
         "representative_genome": ""
     },
@@ -20,7 +20,8 @@
         "VUI202102/03",
         "Eta",
         "G/484K.V3",
-        "20A"
+        "20A",
+        "V-21FEB-03"
     ],
     "sites": [
         "nuc:C1498T",

--- a/constellations/definitions/cB.1.617.1.json
+++ b/constellations/definitions/cB.1.617.1.json
@@ -10,13 +10,14 @@
         "Pango_lineages": [
             "B.1.617.1"
         ],
-	    "mrca_lineage": "B.1.617.1",
-        "PHE_label": "VUI-21APR-01",
+        "mrca_lineage": "B.1.617.1",
+        "PHE_label": "V-21APR-01",
         "representative_genome": ""
     },
     "tags": [
         "B.1.617.1",
-        "VUI-21APR-01"
+        "VUI-21APR-01",
+        "V-21APR-01"
     ],
     "sites": [
         "nuc:C3457T",

--- a/constellations/definitions/cB.1.617.3.json
+++ b/constellations/definitions/cB.1.617.3.json
@@ -10,12 +10,13 @@
             "B.1.617.3"
         ],
 	    "mrca_lineage": "B.1.617.3",
-        "PHE_label": "VUI-21APR-03",
+        "PHE_label": "V-21APR-03",
         "representative_genome": ""
     },
     "tags": [
         "B.1.617.3",
-        "VUI-21APR-03"
+        "VUI-21APR-03",
+        "V-21APR-03"
     ],
     "sites": [
         "nuc:C835T",

--- a/constellations/definitions/cBA.1.json
+++ b/constellations/definitions/cBA.1.json
@@ -9,13 +9,15 @@
             "BA.1"
         ],
         "WHO_label": "Omicron",
-	"mrca_lineage": "BA.1",
+        "mrca_lineage": "BA.1",
         "lineage_name": "BA.1",
         "parent_lineage": "B.1.1.529",
+        "PHE_label": "VOC-21NOV-01",
         "representative_genome": ""
     },
     "tags": [
-        "BA.1"
+        "BA.1",
+        "VOC-21NOV-01"
     ],
     "sites": [
         "orf1ab:K856R",

--- a/constellations/definitions/cBA.2.json
+++ b/constellations/definitions/cBA.2.json
@@ -9,13 +9,15 @@
             "BA.2"
         ],
         "WHO_label": "Omicron",
-	"mrca_lineage": "BA.2",
+        "mrca_lineage": "BA.2",
         "lineage_name": "BA.2",
         "parent_lineage": "B.1.1.529",
+        "PHE_label": "VOC-22JAN-01",
         "representative_genome": ""
     },
     "tags": [
-        "BA.2"
+        "BA.2",
+        "VOC-22JAN-01"
     ],
     "sites": [
         "orf1ab:S135R",

--- a/constellations/definitions/cBA.4.json
+++ b/constellations/definitions/cBA.4.json
@@ -12,10 +12,12 @@
 	      "mrca_lineage": "BA.4",
         "lineage_name": "BA.4",
         "parent_lineage": "B.1.1.529",
+        "PHE_label": "V-22APR-03",
         "representative_genome": ""
     },
     "tags": [
-        "BA.4"
+        "BA.4",
+        "V-22APR-03"
     ],
     "sites": [
       "orf1ab:S135R",

--- a/constellations/definitions/cBA.5.json
+++ b/constellations/definitions/cBA.5.json
@@ -9,13 +9,15 @@
             "BA.5"
         ],
         "WHO_label": "Omicron",
-	      "mrca_lineage": "BA.5",
+        "mrca_lineage": "BA.5",
         "lineage_name": "BA.5",
         "parent_lineage": "B.1.1.529",
+        "PHE_label": "V-22APR-04",
         "representative_genome": ""
     },
     "tags": [
-        "BA.5"
+        "BA.5",
+        "V-22APR-04"
     ],
     "sites": [
       "orf1ab:S135R",

--- a/constellations/definitions/cC.37.json
+++ b/constellations/definitions/cC.37.json
@@ -10,11 +10,13 @@
         ],
 	    "mrca_lineage": "C.37",
 	    "WHO_label": "Lambda",
+		"PHE_label": "V-21JUN-01",
         "representative_genome": ""
     },
     "tags": [
         "Lambda",
-        "C.37"
+        "C.37",
+		"V-21JUN-01"
     ],
     "sites": [
 		"ORF1a:T1246I",

--- a/constellations/definitions/cP.2.json
+++ b/constellations/definitions/cP.2.json
@@ -10,14 +10,15 @@
             "P.2"
         ],
 	    "mrca_lineage": "P.2",
-        "PHE_label": "VUI-21JAN-01",
+        "PHE_label": "V-21JAN-01",
         "WHO_label": "Zeta",
         "representative_genome": ""
     },
     "tags": [
         "P.2",
         "VUI-21JAN-01",
-        "VUI202101/01"
+        "VUI202101/01",
+        "V-21JAN-01"
     ],
     "sites": [
         "ORF1ab:L205V",

--- a/constellations/definitions/cP.3.json
+++ b/constellations/definitions/cP.3.json
@@ -10,15 +10,16 @@
         "Pango_lineages": [
             "P.3"
         ],
-	    "mrca_lineage": "P.3",
-        "PHE_label": "VUI-21MAR-02",
+        "mrca_lineage": "P.3",
+        "PHE_label": "V-21MAR-02",
         "WHO_label": "Theta",
         "representative_genome": ""
     },
     "tags": [
         "P.3",
         "VUI-21MAR-02",
-        "VUI202103/02"
+        "VUI202103/02",
+        "V-21MAR-02"
     ],
     "sites": [
         "nsp3:D736G",

--- a/constellations/definitions/cXE.json
+++ b/constellations/definitions/cXE.json
@@ -9,14 +9,16 @@
             "XE"
         ],
         "WHO_label": "Omicron",
-	"parent_lineage": "XE-parent2",
-	"mrca_lineage": "XE",
+        "parent_lineage": "XE-parent2",
+        "mrca_lineage": "XE",
+        "PHE_label": "V-22APR-02",
         "lineage_name": "XE",
         "representative_genome": ""
     },
     "tags": [
         "XE",
-        "GL2"
+        "GL2",
+        "V-22APR-02"
     ],
     "note": "Unique mutations for XE sublineage",
     "sites": [


### PR DESCRIPTION
UKHSA has replaced the VOC/VUI naming scheme with a VOC/V naming scheme; see https://github.com/phe-genomics/variant_definitions for reference.

I've updated the PHE_label values correspondingly!